### PR TITLE
Add a simple check to see if plain http links are found

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - run: git clone "$CIRCLE_REPOSITORY_URL" html && cd html && git checkout gh-pages && cd ..
       - run:
           name: No HTTP Check
-          command: sh -c "! grep 'http[^s]' src/*"
+          command: sh -c "! grep -r 'http[^s]' src/"
       - run: ~/.cask/bin/cask install
         # Generate build files to /html
       - run: ~/.cask/bin/cask eval "(progn (require 'rj-software-training) (rj-software-training-publish))"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@ jobs:
       - run: git config --global user.name "$GIT_USERNAME" && git config --global user.email "$GIT_EMAIL"
       - run: git clone "$CIRCLE_REPOSITORY_URL" html && cd html && git checkout gh-pages && cd ..
       - run:
-          name: No HTTPS Check
-          command: ! grep 'http[^s]' src/*
+          name: No HTTP Check
+          command: sh -c "! grep 'http[^s]' src/*"
       - run: ~/.cask/bin/cask install
         # Generate build files to /html
       - run: ~/.cask/bin/cask eval "(progn (require 'rj-software-training) (rj-software-training-publish))"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,9 @@ jobs:
       - checkout
       - run: git config --global user.name "$GIT_USERNAME" && git config --global user.email "$GIT_EMAIL"
       - run: git clone "$CIRCLE_REPOSITORY_URL" html && cd html && git checkout gh-pages && cd ..
+      - run:
+          name: No HTTPS Check
+          command: ! grep 'http[^s]' src/*
       - run: ~/.cask/bin/cask install
         # Generate build files to /html
       - run: ~/.cask/bin/cask eval "(progn (require 'rj-software-training) (rj-software-training-publish))"


### PR DESCRIPTION
Will fail if `http[^s]` is found. Let me know if you think this is wrong. 

This isn't a multiple status token, but it should be pretty clear in the circle ui.

We can make it a multiple status token once circleci 2.0 workflows support forked PR's: https://circleci.com/docs/2.0/faq/#can-i-build-fork-prs-using-workflows