### PR TITLE
Vendor Reveal.js on our own domain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,5 +24,5 @@ jobs:
           name: Deploy to github
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
-            cd html && git add . && git commit -m "Autoupdate html sources" || true && git push https://$GH_TOKEN@github.com/RoboJackets/software-training gh-pages || true
+            cd html && git add -A && git commit -m "Autoupdate html sources" || true && git push https://$GH_TOKEN@github.com/RoboJackets/software-training gh-pages || true
             fi

--- a/slides/rj-software-training.el
+++ b/slides/rj-software-training.el
@@ -78,7 +78,7 @@
          :publishing-directory ,(concat proj-base "../html/docs/")
          :publishing-function org-gfm-publish-to-gfm
          :exclude-tags ("slides")))
-    org-reveal-root "https://cdn.jsdelivr.net/reveal.js/3.0.0/"
+    org-reveal-root "https://robojackets.github.io/reveal.js/"
     org-reveal-margin "0.15"))
 
 


### PR DESCRIPTION
This moves reveal.js from the CDN we were using previously onto rj.github, which solves some issues with speaker notes. 

I also attempted to clean up old html files in the auto-exporter, so we have to be careful when merging this.

Closes #20 