### PR TITLE
Implement basic overview file

### DIFF
--- a/slides/Cask
+++ b/slides/Cask
@@ -6,6 +6,7 @@
 
 
 (development
+ (depends-on "f")
  (depends-on "ert-runner")
  (depends-on "htmlize")
  (depends-on "ox-gfm")

--- a/slides/overview/index.org
+++ b/slides/overview/index.org
@@ -1,0 +1,10 @@
+#+TITLE: Overview of Training Materials
+#+AUTHOR: Jay Kamat
+#+EMAIL: jaygkamat@gmail.com
+#+DATE: <2017-08-08 Tue>
+
+
+# See project definition file for export function
+#+BEGIN_SRC emacs-lisp :exports results :results raw
+(rj-generate-project-toc)
+#+END_SRC

--- a/slides/rj-software-training.el
+++ b/slides/rj-software-training.el
@@ -20,6 +20,8 @@
 (require 'ox-gfm)
 ;; file manipulation lib
 (require 'f)
+;; Hash table (and more) library
+(require 'subr-x)
 
 ;;; Code:
 ;;;; Project root def


### PR DESCRIPTION
This PR adds a 'overview' file to the list of files exported, which is intended to supplement and/or replace the manual README updating we've been doing. I also added a html export as well.

This PR also adds [a new dependency](https://github.com/rejeep/f.el) so you will need to rerun `cask install` to build slides (CI will be unaffected, I think).

Essentially, this adds a new file which (should) link to all the other files in the project, sorted and grouped by the folder they're in. 

A flow for someone trying to find (x) for a week could be:

1. Navigate to the overview slide deck (or docs page (or html page)), depending on what type of content you want to view. This could be done with links from the readme at the master branch.
2. Go through the slides/docs/site to find the topic you want
3. Click on a link to get transferred to the respective materials.

One criticism of this is that the slides overview is itself also a slide deck, which I think is a little clunky for viewing slides in particular (I could hard code or build the links myself, but that smells wrong).

Best case this would turn the README into a list of `(docs slides html <anything else>)` that you would get transfered to the overview slide for the section. 
Worst case is no one would use this :cry:.

(I'm also probably going to clean and re-package this eventually as a library, since it's useful if you make a lot of org projects).

Let me know what you think, or if you spot issues.
