### PR TITLE
Add dependency on STSL for individual targets

### DIFF
--- a/hardware_applications/week1/CMakeLists.txt
+++ b/hardware_applications/week1/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_executable(week1_final final_code.cpp)
+add_dependencies(week1_final STSL)
 target_link_libraries(week1_final ${STSL_LIBS})

--- a/hardware_applications/week2/CMakeLists.txt
+++ b/hardware_applications/week2/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_executable(week2 starter_main.cpp starter_helpers.cpp starter_helpers.h)
+add_dependencies(week2 STSL)
 target_link_libraries(week2 ${STSL_LIBS})
 
 add_executable(week2_final final_main.cpp final_helpers.cpp final_helpers.h)
+add_dependencies(week2_final STSL)
 target_link_libraries(week2_final ${STSL_LIBS})


### PR DESCRIPTION
When compiling with multithreading, the build fails the first time, but succeeds on a second run (à la IGVC).

This patch fixes that by adding the STSL as a dependency of individual build targets.