### PR TITLE
Adds projects folder with structure for 2019 Platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ html/
 .DS_Store
 
 CMakeFiles/
+projects/.c9/*
+*.o
+

--- a/projects/.c9/runners/C++ (RoboJackets).run
+++ b/projects/.c9/runners/C++ (RoboJackets).run
@@ -3,7 +3,7 @@
 {
   "script": [
     "set -e",
-    "export LD_LIBRARY_PATH=/opt/opencv-4.0.1/lib:/usr/local/lib:$LD_LIBRARY_PATH",
+    "export LD_LIBRARY_PATH=/opt/opencv-4.1.1/lib:/usr/local/lib:$LD_LIBRARY_PATH",
     "if [ \"$debug\" == true ]; then ",
     "echo 'DEBUG MODE'",
     "/usr/bin/g++ -ggdb3 -std=c++14 $file_path/*.cpp -o runnable.out -L/usr/lib -lrobotcontrol -L/usr/local/lib -lSTSL `pkg-config --cflags --libs opencv`",

--- a/projects/.c9/runners/C++ (RoboJackets).run
+++ b/projects/.c9/runners/C++ (RoboJackets).run
@@ -1,0 +1,23 @@
+// This file overrides the built-in C++ (simple) runner
+// For more information see http://docs.c9.io:8080/#!/api/run-method-run
+{
+  "script": [
+    "set -e",
+    "export LD_LIBRARY_PATH=/opt/opencv-4.0.1/lib:/usr/local/lib:$LD_LIBRARY_PATH",
+    "if [ \"$debug\" == true ]; then ",
+    "echo 'DEBUG MODE'",
+    "/usr/bin/g++ -ggdb3 -std=c++14 $file_path/*.cpp -o runnable.out -L/usr/lib -lrobotcontrol -L/usr/local/lib -lSTSL `pkg-config --cflags --libs opencv`",
+    "chmod 755 runnable.out",
+    "node $HOME/.c9/bin/c9gdbshim.js runnable.out $args",
+    "else",
+    "/usr/bin/g++ -std=c++14 $file_path/*.cpp -o runnable.out -L/usr/lib -lrobotcontrol -L/usr/local/lib -lSTSL `pkg-config --cflags --libs opencv`",
+    "chmod 755 runnable.out",
+    "./runnable.out $args",
+    "fi"
+  ],
+  "info": "Running $file",
+  "debugger": "gdb",
+  "$debugDefaultState": false,
+  "env": {},
+  "selector": "^.*\\.(cpp|cc)$"
+}

--- a/projects/exercises/01/main.cpp
+++ b/projects/exercises/01/main.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "Hello, World!" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
This PR adds the `projects` folder, which should be used for all of our in-classroom robot projects. 
This folder is setup as the default workspace in the Cloud9 IDE on the new platforms.