### PR TITLE
Adds pthread to the RoboJackets C++ runner.

### DIFF
--- a/projects/.c9/runners/C++ (RoboJackets).run
+++ b/projects/.c9/runners/C++ (RoboJackets).run
@@ -6,11 +6,11 @@
     "export LD_LIBRARY_PATH=/opt/opencv-4.1.1/lib:/usr/local/lib:$LD_LIBRARY_PATH",
     "if [ \"$debug\" == true ]; then ",
     "echo 'DEBUG MODE'",
-    "/usr/bin/g++ -ggdb3 -std=c++14 $file_path/*.cpp -o runnable.out -L/usr/lib -lrobotcontrol -L/usr/local/lib -lSTSL `pkg-config --cflags --libs opencv`",
+    "/usr/bin/g++ -ggdb3 -std=c++14 $file_path/*.cpp -o runnable.out -L/usr/lib -lrobotcontrol -L/usr/local/lib -lSTSL `pkg-config --cflags --libs opencv` -lpthread",
     "chmod 755 runnable.out",
     "node $HOME/.c9/bin/c9gdbshim.js runnable.out $args",
     "else",
-    "/usr/bin/g++ -std=c++14 $file_path/*.cpp -o runnable.out -L/usr/lib -lrobotcontrol -L/usr/local/lib -lSTSL `pkg-config --cflags --libs opencv`",
+    "/usr/bin/g++ -std=c++14 $file_path/*.cpp -o runnable.out -L/usr/lib -lrobotcontrol -L/usr/local/lib -lSTSL `pkg-config --cflags --libs opencv` -lpthread",
     "chmod 755 runnable.out",
     "./runnable.out $args",
     "fi"


### PR DESCRIPTION
STSL now uses the standard threading library, which means we need to link against pthread in our Cloud9 runner. This PR adds pthread to the runner.