### PR TITLE
Coordinate Frame Student Code

### DIFF
--- a/coordiante_transform/CMakeLists.txt
+++ b/coordiante_transform/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 3.5)
+project(coordinate_transform)
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
+find_package(image_transport REQUIRED)
+find_package(cv_bridge REQUIRED)
+find_package(nav_msgs REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(tf2_eigen REQUIRED)
+find_package(stsl_interfaces REQUIRED)
+
+add_library(${PROJECT_NAME}_components SHARED src/coordinate_transform_component.cpp)
+ament_target_dependencies(${PROJECT_NAME}_components
+        "rclcpp"
+        "rclcpp_components"
+        "tf2_ros"
+        "tf2_eigen"
+        "stsl_interfaces"
+        )
+rclcpp_components_register_node(
+        ${PROJECT_NAME}_components
+        PLUGIN "coordinate_transform::CoordinateTransformComponent"
+        EXECUTABLE ${PROJECT_NAME}_node
+)
+
+install(TARGETS ${PROJECT_NAME}_components
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION lib/${PROJECT_NAME}
+        )
+
+install(
+        DIRECTORY
+        launch
+        config
+        DESTINATION share/${PROJECT_NAME}
+)
+
+if(BUILD_TESTING)
+    find_package(ament_lint_auto REQUIRED)
+    ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/coordiante_transform/CMakeLists.txt
+++ b/coordiante_transform/CMakeLists.txt
@@ -13,30 +13,31 @@ find_package(tf2_eigen REQUIRED)
 find_package(stsl_interfaces REQUIRED)
 
 add_library(${PROJECT_NAME}_components SHARED src/coordinate_transform_component.cpp)
-ament_target_dependencies(${PROJECT_NAME}_components
+ament_target_dependencies(
+        ${PROJECT_NAME}_components
         "rclcpp"
         "rclcpp_components"
         "tf2_ros"
         "tf2_eigen"
         "visualization_msgs"
         "stsl_interfaces"
-        )
+)
 rclcpp_components_register_node(
         ${PROJECT_NAME}_components
         PLUGIN "coordinate_transform::CoordinateTransformComponent"
         EXECUTABLE ${PROJECT_NAME}_node
 )
 
-install(TARGETS ${PROJECT_NAME}_components
+install(
+        TARGETS ${PROJECT_NAME}_components
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION lib/${PROJECT_NAME}
-        )
+)
 
 install(
         DIRECTORY
         launch
-        config
         DESTINATION share/${PROJECT_NAME}
 )
 

--- a/coordiante_transform/CMakeLists.txt
+++ b/coordiante_transform/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(image_transport REQUIRED)
 find_package(cv_bridge REQUIRED)
+find_package(visualization_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_eigen REQUIRED)
@@ -17,6 +18,7 @@ ament_target_dependencies(${PROJECT_NAME}_components
         "rclcpp_components"
         "tf2_ros"
         "tf2_eigen"
+        "visualization_msgs"
         "stsl_interfaces"
         )
 rclcpp_components_register_node(

--- a/coordiante_transform/launch/coordinate_transform.launch.py
+++ b/coordiante_transform/launch/coordinate_transform.launch.py
@@ -19,6 +19,7 @@
 # THE SOFTWARE.
 
 from launch import LaunchDescription
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
@@ -27,6 +28,9 @@ def generate_launch_description():
         Node(
             package='coordinate_transform',
             executable='coordinate_transform_node',
-            output='screen'
+            output='screen',
+            parameters=[
+                {'use_sim_time': LaunchConfiguration('use_sim_time', default='false')}
+            ]
         )
     ])

--- a/coordiante_transform/launch/coordinate_transform.launch.py
+++ b/coordiante_transform/launch/coordinate_transform.launch.py
@@ -1,0 +1,32 @@
+# Copyright 2021 RoboJackets
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    return LaunchDescription([
+        Node(
+            package='coordinate_transform',
+            executable='coordinate_transform_node',
+            output='screen'
+        )
+    ])

--- a/coordiante_transform/package.xml
+++ b/coordiante_transform/package.xml
@@ -13,6 +13,7 @@
     <depend>rclcpp_components</depend>
     <depend>tf2_ros</depend>
     <depend>tf2_eigen</depend>
+    <depend>visualization_msgs</depend>
     <depend>stsl_interfaces</depend>
 
     <test_depend>ament_lint_auto</test_depend>

--- a/coordiante_transform/package.xml
+++ b/coordiante_transform/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+    <name>coordinate_transform</name>
+    <version>0.0.0</version>
+    <description>TODO: Package description</description>
+    <maintainer email="jgibson37@gatech.edu">Jason Gibson</maintainer>
+    <license>MIT</license>
+
+    <buildtool_depend>ament_cmake</buildtool_depend>
+
+    <depend>rclcpp</depend>
+    <depend>rclcpp_components</depend>
+    <depend>tf2_ros</depend>
+    <depend>tf2_eigen</depend>
+    <depend>stsl_interfaces</depend>
+
+    <test_depend>ament_lint_auto</test_depend>
+    <test_depend>ament_lint_common</test_depend>
+
+    <export>
+        <build_type>ament_cmake</build_type>
+    </export>
+</package>

--- a/coordiante_transform/package.xml
+++ b/coordiante_transform/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
     <name>coordinate_transform</name>
     <version>0.0.0</version>
-    <description>TODO: Package description</description>
+    <description>A package for transforming a fiducial marker from camera frame to body frame</description>
     <maintainer email="jgibson37@gatech.edu">Jason Gibson</maintainer>
     <license>MIT</license>
 

--- a/coordiante_transform/src/coordinate_transform_component.cpp
+++ b/coordiante_transform/src/coordinate_transform_component.cpp
@@ -1,0 +1,152 @@
+// Copyright 2021 RoboJackets
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_components/register_node_macro.hpp>
+#include <stsl_interfaces/msg/tag_array.hpp>
+#include <geometry_msgs/msg/point.h>
+#include <geometry_msgs/msg/quaternion.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_eigen/tf2_eigen.h>
+
+namespace coordinate_transform {
+class CoordinateTransformComponent : public rclcpp::Node
+{
+public:
+  explicit CoordinateTransformComponent(const rclcpp::NodeOptions & options)
+  : rclcpp::Node("coordinate_transformer", options), tf_buffer_(get_clock()), tf_listener_(tf_buffer_)
+  {
+    tag_sub_ = this->create_subscription<stsl_interfaces::msg::TagArray>("/aruco_tag_detector/tags",
+            10, std::bind(&CoordinateTransformComponent::DetectionCallback, this, std::placeholders::_1));
+
+    tag_publisher_ = this->create_publisher<stsl_interfaces::msg::TagArray>("~/tags_transformed", 1);
+  }
+
+private:
+  tf2_ros::Buffer tf_buffer_;
+  tf2_ros::TransformListener tf_listener_;
+  rclcpp::Subscription<stsl_interfaces::msg::TagArray>::SharedPtr tag_sub_;
+  rclcpp::Publisher<stsl_interfaces::msg::TagArray>::SharedPtr tag_publisher_;
+
+  void DetectionCallback(const stsl_interfaces::msg::TagArray::SharedPtr tag_array_msg)
+  {
+    std::string tf_error_string;
+    if (!tf_buffer_.canTransform(
+            "base_footprint", tag_array_msg->header.frame_id,
+            tag_array_msg->header.stamp, tf2::durationFromSec(0.1),
+            &tf_error_string))
+    {
+      RCLCPP_WARN_THROTTLE(
+              get_logger(), *get_clock(), 1000, "Could not lookup transform. %s",
+              tf_error_string);
+      return;
+    }
+
+    // find the transform from the camera to base footprint
+    // TODO why flipped?
+    const auto tf_transform =
+            tf_buffer_.lookupTransform("base_footprint", "camera_link", tag_array_msg->header.stamp);
+    const Eigen::Isometry3d eigen_transform = tf2::transformToEigen(tf_transform);
+
+    // BEGIN STUDENT CODE
+    // creates a matrix that goes from camera to standard ROS coordinates
+    Eigen::Matrix4d optical = getRotMatForOpticalFrame();
+
+    // create a new tag array message
+    stsl_interfaces::msg::TagArray new_tag_array_msg;
+    // copy the header information
+    new_tag_array_msg.header = tag_array_msg->header;
+    // change the frame_id to be the correct reference frame
+    new_tag_array_msg.header.frame_id = "/base_footprint";
+    // END STUDENT CODE
+
+    // to convert a quaternion to a rotation matrix use the following
+
+    // BEGIN STUDENT CODE
+    // iterate over each tag to and transform it into body frame
+    for(int i = 0; i < tag_array_msg->tags.size(); i++) {
+      stsl_interfaces::msg::Tag new_tag;
+      new_tag.id = tag_array_msg->tags[i].id;
+
+      geometry_msgs::msg::Point old_tag_position = tag_array_msg->tags[i].pose.position;
+
+      // extract the important parts of the pose
+      Eigen::Vector4d pose = Eigen::Vector4d(old_tag_position.x, old_tag_position.y, old_tag_position.z, 1);
+
+      // apply the transform
+      pose = eigen_transform.matrix() * optical * pose;
+
+      new_tag.pose.position.x = pose(0);
+      new_tag.pose.position.y = pose(1);
+      new_tag.pose.position.z = pose(2);
+
+      // get the orientation of the tag
+      Eigen::Matrix4d tag_orientation = convertQuatToRotMat(tag_array_msg->tags[i].pose.orientation);
+      tag_orientation = eigen_transform.matrix() * optical * tag_orientation;
+      new_tag.pose.orientation = convertRotMatToQuat(tag_orientation);
+
+      new_tag_array_msg.tags.push_back(new_tag);
+    }
+    tag_publisher_->publish(new_tag_array_msg);
+    // END STUDENT CODE
+  }
+
+  Eigen::Matrix4d getRotMatForOpticalFrame() {
+    Eigen::Matrix4d R_roll;
+    // BEGIN STUDENT CODE
+    R_roll << 1, 0, 0, 0,
+            0, cos(-M_PI/2), sin(-M_PI/2), 0,
+            0, -sin(-M_PI/2), cos(-M_PI/2), 0,
+            0,0,0,1;
+    // END STUDENT CODE
+
+    Eigen::Matrix4d R_yaw;
+    // BEGIN STUDENT CODE
+    R_yaw << cos(-M_PI/2), sin(-M_PI/2), 0, 0,
+            -sin(-M_PI/2), cos(-M_PI/2), 0, 0,
+            0, 0, 1, 0,
+            0,0,0,1;
+    // END STUDENT CODE
+    return R_yaw * R_roll;
+  }
+
+  Eigen::Matrix4d convertQuatToRotMat(geometry_msgs::msg::Quaternion quat) {
+    Eigen::Quaterniond e_quat = Eigen::Quaterniond(quat.w, quat.x, quat.y, quat.z);
+    Eigen::Matrix4d result_mat = Eigen::Matrix4d::Zero();
+    result_mat.block<3,3>(0,0) = e_quat.normalized().toRotationMatrix();
+    result_mat(3,3) = 1.0;
+    return result_mat;
+  }
+
+  geometry_msgs::msg::Quaternion convertRotMatToQuat(Eigen::Matrix4d homo_mat) {
+    geometry_msgs::msg::Quaternion quat;
+    Eigen::Quaterniond e_quat = Eigen::Quaterniond(homo_mat.block<3,3>(0,0));
+
+    quat.w = e_quat.w();
+    quat.x = e_quat.x();
+    quat.w = e_quat.w();
+    quat.z = e_quat.z();
+
+    return quat;
+  }
+};
+} // namespace coordinate_transform
+
+RCLCPP_COMPONENTS_REGISTER_NODE(coordinate_transform::CoordinateTransformComponent)

--- a/coordiante_transform/src/coordinate_transform_component.cpp
+++ b/coordiante_transform/src/coordinate_transform_component.cpp
@@ -113,7 +113,7 @@ private:
 
     // visualization code
     visualization_msgs::msg::MarkerArray marker_array;
-    for(const stsl_interfaces::msg::Tag tag : new_tag_array_msg.tags)
+    for(const stsl_interfaces::msg::Tag & tag : new_tag_array_msg.tags)
     {
       visualization_msgs::msg::Marker marker;
       marker.header.frame_id = "base_footprint";

--- a/coordiante_transform/src/coordinate_transform_component.cpp
+++ b/coordiante_transform/src/coordinate_transform_component.cpp
@@ -119,9 +119,10 @@ private:
       marker.header.frame_id = "base_footprint";
       marker.header.stamp = tag_array_msg->header.stamp;
       marker.id = tag.id;
+      marker.ns = "/coordinate_transform";
       marker.type = visualization_msgs::msg::Marker::CUBE;
       marker.action = visualization_msgs::msg::Marker::ADD;
-      marker.lifetime = rclcpp::Duration(0, 250000000);
+      marker.lifetime = rclcpp::Duration(0, 150000000);
 
       marker.pose = tag.pose;
 

--- a/coordiante_transform/src/coordinate_transform_component.cpp
+++ b/coordiante_transform/src/coordinate_transform_component.cpp
@@ -27,6 +27,7 @@
 #include <geometry_msgs/msg/quaternion.h>
 #include <tf2_ros/transform_listener.h>
 #include <tf2_eigen/tf2_eigen.h>
+#include <string>
 
 using namespace std::chrono_literals;
 
@@ -175,6 +176,6 @@ private:
     return tf2::toMsg(Eigen::Quaterniond(homo_mat.block<3, 3>(0, 0)));
   }
 };
-} // namespace coordinate_transform
+}  // namespace coordinate_transform
 
 RCLCPP_COMPONENTS_REGISTER_NODE(coordinate_transform::CoordinateTransformComponent)


### PR DESCRIPTION
- This node transforms the aruco marker that is in camera frame into body frame (base_footprint).
- The transform combines two different transforms base_footprint -> camera_link and then camera_link -> camera_link_optical.
  - The first transform comes from tf
  - The second is coded up by the students using a rotation matrix for roll and yaw (combined into a single matrix in a method)
- The students are responsible for coding the transforms and for making sure they are applying the rotations in the correct order.


Open Questions:
What removing Eigen looks like. I think the student section needs a better defined scope and I don't want them to see Eigen template errors week one. So it will likely result in abstracting the multiplication and matrix building into a data type they know (vector) and then writing helpers that convert back and forth.

![coordinate_transform](https://user-images.githubusercontent.com/13954395/124512770-31389200-dda7-11eb-92dc-c0b61ebf17c4.gif)

