### PR TITLE
Adds orchestration to bringup files.

### DIFF
--- a/rj_training_bringup/CMakeLists.txt
+++ b/rj_training_bringup/CMakeLists.txt
@@ -8,6 +8,7 @@ install(
   behavior_trees
   config
   launch
+  mineral_sample_sets
   rviz_config
   DESTINATION share/${PROJECT_NAME}
 )

--- a/rj_training_bringup/launch/full_game_stack.launch.xml
+++ b/rj_training_bringup/launch/full_game_stack.launch.xml
@@ -14,4 +14,10 @@
     <include file="$(find-pkg-share rj_training_bringup)/launch/navigation.launch.py">
         <param name="use_sim_time" value="$(var use_sim_time)"/>
     </include>
+    <node pkg="peak_finder" exec="peak_finder_node">
+        <param name="use_sim_time" value="$(var use_sim_time)"/>
+    </node>
+    <include file="$(find-pkg-share mission_orchestration)/launch/mission_orchestrator.launch.py">
+        <param name="use_sim_time" value="$(var use_sim_time)"/>
+    </include>
 </launch>

--- a/rj_training_bringup/launch/full_game_stack.launch.xml
+++ b/rj_training_bringup/launch/full_game_stack.launch.xml
@@ -1,23 +1,24 @@
 <launch>
     <arg name="use_sim_time" default="True"/>
     <include file="$(find-pkg-share traini_bringup)/launch/tag_detector.launch.py">
-        <param name="use_sim_time" value="$(var use_sim_time)"/>
+        <arg name="use_sim_time" value="$(var use_sim_time)"/>
     </include>
     <include file="$(find-pkg-share obstacle_detector)/launch/obstacle_detector.launch.py"/>
     <include file="$(find-pkg-share rj_training_bringup)/launch/fake_localizer.launch.py">
         <!-- TODO (barulicm) Replace with particle filter localizer when it's ready -->
-        <param name="use_sim_time" value="$(var use_sim_time)"/>
+        <arg name="use_sim_time" value="$(var use_sim_time)"/>
     </include>
     <include file="$(find-pkg-share elevation_server)/launch/elevation_server.launch.py">
-        <param name="use_sim_time" value="$(var use_sim_time)"/>
+        <arg name="use_sim_time" value="$(var use_sim_time)"/>
     </include>
     <include file="$(find-pkg-share rj_training_bringup)/launch/navigation.launch.py">
-        <param name="use_sim_time" value="$(var use_sim_time)"/>
+        <arg name="use_sim_time" value="$(var use_sim_time)"/>
     </include>
     <node pkg="peak_finder" exec="peak_finder_node">
-        <param name="use_sim_time" value="$(var use_sim_time)"/>
+        <arg name="use_sim_time" value="$(var use_sim_time)"/>
     </node>
     <include file="$(find-pkg-share mission_orchestration)/launch/mission_orchestrator.launch.py">
-        <param name="use_sim_time" value="$(var use_sim_time)"/>
+        <arg name="use_sim_time" value="$(var use_sim_time)"/>
+        <arg name="mineral_samples_file" value="$(find-pkg-share rj_training_bringup)/mineral_sample_sets/default.yaml"/>
     </include>
 </launch>

--- a/rj_training_bringup/launch/navigation.launch.py
+++ b/rj_training_bringup/launch/navigation.launch.py
@@ -20,8 +20,7 @@
 
 import os
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
-from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory

--- a/rj_training_bringup/launch/navigation.launch.py
+++ b/rj_training_bringup/launch/navigation.launch.py
@@ -23,32 +23,104 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
+from nav2_common.launch import RewrittenYaml
 
 
 def generate_launch_description():
+
+    use_sim_time = LaunchConfiguration('use_sim_time')
+
+    tf_remappings = [('/tf', 'tf'), ('/tf_static', 'tf_static')]
+
+    lifecycle_nodes = ['controller_server',
+                       'planner_server',
+                       'recoveries_server',
+                       'bt_navigator']
+
+    behavior_tree = os.path.join(get_package_share_directory(
+        'rj_training_bringup'), 'behavior_trees', 'navigate.xml')
+
+    params_file = LaunchConfiguration('params_file')
+
+    param_substitutions = {
+        'use_sim_time': use_sim_time,
+        'default_bt_xml_filename': behavior_tree
+    }
+
+    configured_params = RewrittenYaml(
+        source_file=params_file,
+        root_key='',
+        param_rewrites=param_substitutions,
+        convert_types=True
+    )
+
     return LaunchDescription([
         DeclareLaunchArgument(
             name='use_sim_time',
-            default_value='True'
+            default_value='false'
         ),
+
         DeclareLaunchArgument(
-            name="navigation_params_file",
+            name='params_file',
             default_value=os.path.join(get_package_share_directory(
                 'rj_training_bringup'), 'config', 'nav_params.yaml')
         ),
-        DeclareLaunchArgument(
-            name="behavior_tree_file",
-            default_value=os.path.join(get_package_share_directory(
-                'rj_training_bringup'), 'behavior_trees', 'navigate.xml')
+
+        Node(
+            package='nav2_bt_navigator',
+            executable='bt_navigator',
+            name='bt_navigator',
+            output='screen',
+            parameters=[configured_params],
+            remappings=tf_remappings
         ),
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource(os.path.join(
-                get_package_share_directory('nav2_bringup'), 'launch', 'navigation_launch.py')),
-            launch_arguments={'namespace': '',
-                              'use_namespace': 'False',
-                              'use_sim_time': LaunchConfiguration('use_sim_time'),
-                              'params_file': LaunchConfiguration('navigation_params_file'),
-                              'default_bt_xml_filename': LaunchConfiguration('behavior_tree_file'),
-                              'autostart': 'True'}.items())
+
+        Node(
+            package='nav2_controller',
+            executable='controller_server',
+            output='screen',
+            parameters=[configured_params],
+            remappings=tf_remappings
+        ),
+
+        Node(
+            package='nav2_planner',
+            executable='planner_server',
+            name='planner_server',
+            output='screen',
+            parameters=[configured_params],
+            remappings=tf_remappings
+        ),
+
+        Node(
+            package='nav2_recoveries',
+            executable='recoveries_server',
+            name='recoveries_server',
+            output='screen',
+            parameters=[configured_params],
+            remappings=tf_remappings
+        ),
+
+        # Node(
+        #     package='nav2_map_server',
+        #     executable='map_server',
+        #     name='map_server',
+        #     output='screen',
+        #     parameters=[],
+        #     remappings=tf_remappings
+        # ),
+
+        Node(
+            package='nav2_lifecycle_manager',
+            executable='lifecycle_manager',
+            name='lifecycle_manager_navigation',
+            output='screen',
+            parameters=[
+                {'use_sim_time': use_sim_time},
+                {'autostart': True},
+                {'node_names': lifecycle_nodes}
+            ]
+        )
     ])

--- a/rj_training_bringup/launch/projects/color_detection.launch.xml
+++ b/rj_training_bringup/launch/projects/color_detection.launch.xml
@@ -3,6 +3,6 @@
     <include if="$(var simulation)" file="$(find-pkg-share traini_bringup)/launch/traini_simulation.launch.py"/>
     <include file="$(find-pkg-share obstacle_detector)/launch/obstacle_detector.launch.py"/>
     <node pkg="rviz2" exec="rviz2" args="-d $(find-pkg-share rj_training_bringup)/rviz_config/color_detection.rviz">
-        <param name="use_sim_time" value="$(var simulation)"/>
+        <arg name="use_sim_time" value="$(var simulation)"/>
     </node>
 </launch>

--- a/rj_training_bringup/launch/projects/optimization.launch.xml
+++ b/rj_training_bringup/launch/projects/optimization.launch.xml
@@ -11,9 +11,9 @@
         <arg name="use_sim_time" value="$(var use_sim_time)"/>
     </include>
     <node pkg="peak_finder" exec="peak_finder_node">
-        <param name="use_sim_time" value="$(var use_sim_time)"/>
+        <arg name="use_sim_time" value="$(var use_sim_time)"/>
     </node>
     <node pkg="rviz2" exec="rviz2" args="-d $(find-pkg-share rj_training_bringup)/rviz_config/optimization.rviz">
-        <param name="use_sim_time" value="$(var use_sim_time)"/>
+        <arg name="use_sim_time" value="$(var use_sim_time)"/>
     </node>
 </launch>

--- a/rj_training_bringup/launch/projects/planning.launch.xml
+++ b/rj_training_bringup/launch/projects/planning.launch.xml
@@ -6,7 +6,7 @@
     </include>
     <include file="$(find-pkg-share rj_training_bringup)/launch/navigation.launch.py">
         <arg name="use_sim_time" value="$(var use_sim_time)"/>
-        <arg name="navigation_params_file" value="$(find-pkg-share rj_training_bringup)/config/planning_project_nav_params.yaml"/>
+        <arg name="params_file" value="$(find-pkg-share rj_training_bringup)/config/planning_project_nav_params.yaml"/>
     </include>
     <node pkg="rviz2" exec="rviz2" args="-d $(find-pkg-share rj_training_bringup)/rviz_config/optimization.rviz">
         <param name="use_sim_time" value="$(var use_sim_time)"/>

--- a/rj_training_bringup/launch/projects/planning.launch.xml
+++ b/rj_training_bringup/launch/projects/planning.launch.xml
@@ -9,6 +9,6 @@
         <arg name="params_file" value="$(find-pkg-share rj_training_bringup)/config/planning_project_nav_params.yaml"/>
     </include>
     <node pkg="rviz2" exec="rviz2" args="-d $(find-pkg-share rj_training_bringup)/rviz_config/optimization.rviz">
-        <param name="use_sim_time" value="$(var use_sim_time)"/>
+        <arg name="use_sim_time" value="$(var use_sim_time)"/>
     </node>
 </launch>

--- a/rj_training_bringup/mineral_sample_sets/default.yaml
+++ b/rj_training_bringup/mineral_sample_sets/default.yaml
@@ -1,0 +1,51 @@
+- header:
+    stamp:
+      sec: 0
+      nanosec: 0
+    frame_id: 'map'
+  pose:
+    pose:
+      position:
+        x: 0.0
+        y: 0.0
+        z: 0.0
+      orientation:
+        x: 0.0
+        y: 0.0
+        z: 0.0
+        w: 1.0
+    covariance: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+- header:
+    stamp:
+      sec: 0
+      nanosec: 0
+    frame_id: 'map'
+  pose:
+    pose:
+      position:
+        x: 0.2
+        y: 0.0
+        z: 0.0
+      orientation:
+        x: 0.0
+        y: 0.0
+        z: 0.0
+        w: 1.0
+    covariance: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+- header:
+    stamp:
+      sec: 0
+      nanosec: 0
+    frame_id: 'map'
+  pose:
+    pose:
+      position:
+        x: 0.2
+        y: 0.2
+        z: 0.0
+      orientation:
+        x: 0.0
+        y: 0.0
+        z: 0.0
+        w: 1.0
+    covariance: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]


### PR DESCRIPTION
This PR modifies the bringup files to use the new mission_orchestration package in stsl. This package coordinates all of the individual robot behaviors needed for the game via a behavior tree. To see the default behavior for the game (at least as much of it as currently exists) see [default_mission_tree.xml](https://github.com/RoboJackets/stsl/blob/main/mission_orchestration/behavior_trees/default_mission_tree.xml) in stsl.

I also fixed a problem with some of the other launch files where I had mistakenly used `param` tags instead of `arg` tags when including other launch files.