### PR TITLE
Adds general meeting locations to syllabus

### DIFF
--- a/Syllabus.md
+++ b/Syllabus.md
@@ -28,8 +28,12 @@ For more information about team meeting schedules and locations, check with each
   - Mondays, 7:00 - 9:30pm
 
 ### General Software Training Meetings
-- Wednesdays, 4:30 - 6:30pm, Location TBD
-- Thursdays, 4:30 - 6:30pm, Location TBD
+- Wednesdays
+  - 4:30 - 6:30pm
+  - Van Leer, room C241
+- Thursdays
+  - 4:30 - 6:30pm
+  - Molecular Science and Engineering Building (MoSE), room 1201A
 
 ## Resources
 


### PR DESCRIPTION
I pulled these locations from the website calendar events: https://robojackets.org/event/software-training-8/?instance_id=11324

I think the only TODOs left for this document now are to fill out the links for the projects and videos as those are published.