### PR TITLE
Get rwm qos profile

### DIFF
--- a/projects/week_2/Instructions.md
+++ b/projects/week_2/Instructions.md
@@ -261,7 +261,7 @@ camera_subscriber_ = image_transport::create_camera_subscription(
       std::bind(
         &ObstacleDetector::ImageCallback, this, std::placeholders::_1,
         std::placeholders::_2),
-      "raw", rclcpp::SensorDataQoS());
+      "raw", rclcpp::SensorDataQoS().get_rmw_qos_profile());
 ```
 
 The first argument, `this` gives the function a reference to our node object.

--- a/reference_solutions/obstacle_detector/src/obstacle_detector.cpp
+++ b/reference_solutions/obstacle_detector/src/obstacle_detector.cpp
@@ -52,7 +52,7 @@ public:
       std::bind(
         &ObstacleDetector::ImageCallback, this, std::placeholders::_1,
         std::placeholders::_2),
-      "raw", rclcpp::SensorDataQoS());
+      "raw", rclcpp::SensorDataQoS().get_rmw_qos_profile());
     // END STUDENT CODE
     
     declare_parameters<int>(


### PR DESCRIPTION
Should `rclcpp::SensorDataQoS()` be `rclcpp::SensorDataQoS().get_rmw_qos_profile()`? `create_camera_subscription` seems to want a `rmw_qos_profile_t` struct instead of a QOS object.